### PR TITLE
Improve class Evaluator

### DIFF
--- a/prism/src/common/iterable/Reducible.java
+++ b/prism/src/common/iterable/Reducible.java
@@ -27,7 +27,7 @@ import java.util.function.*;
  * <li>Filter all odd numbers
  * <li>Collect the filtered numbers in a new {@code ArrayList}
  * </ol>
- * Please note that {@link Reducible#mapToInt} and {@link Reducible#filter} only wrap the underlying reducible.
+ * Please note that {@link Reducible#mapToInt} and {@link Reducible#filter} only wrap the underlying Reducible.
  * The actual computation happens on-the-fly when {@code collect} is called.
  *
  * <p><em>Transformation operations</em> (known as <a href="package-summary.html#StreamOps">intermediate operations</a> on streams)
@@ -43,7 +43,7 @@ import java.util.function.*;
  * Please note that implementors of the interface may consume no elements if the result of an accumulation can be computed directly.
  *
  * @param <E> the type of elements returned by this Reducible
- * @param <E_CAT> the type of reducibles accepted by  {@link Reducible#concat concat}
+ * @param <E_CAT> the type of Reducibles accepted by  {@link Reducible#concat concat}
  *ø
  * @see java.util.stream.Stream Stream
  */
@@ -194,6 +194,96 @@ public interface Reducible<E, E_CAT>
 	}
 
 	/**
+	 * Concatenate a sequence of Iterables.
+	 * The returned FunctionalIterable iterates over the elements in the order of the argument sequence.
+	 *
+	 * @param iterables the {@link Iterable}s to concatenate
+	 * @return a {@link FunctionalIterable} that iterates over the elements of each Iterable
+	 */
+	static <E> FunctionalIterable<E> concat(Iterable<? extends Iterable<? extends E>> iterables)
+	{
+		return new ChainedIterable.Of(iterables);
+	}
+
+	/**
+	 * Concatenate a sequence of Iterators.
+	 * The returned FunctionalIterator iterates over the elements in the order of the argument sequence.
+	 *
+	 * @param iterators the {@link Iterator}s to concatenate
+	 * @return a {@link FunctionalIterator} that iterates over the elements of each Iterator
+	 */
+	static <E> FunctionalIterator<E> concat(Iterator<? extends Iterator<? extends E>> iterators)
+	{
+		return new ChainedIterator.Of(iterators);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code double}.
+	 *
+	 * @param iterables the {@link PrimitiveIterable.OfDouble}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterable.OfDouble} that iterates over the elements of each Iterable
+	 */
+	static FunctionalPrimitiveIterable.OfDouble concatDouble(Iterable<? extends PrimitiveIterable.OfDouble> iterables)
+	{
+		return new ChainedIterable.OfDouble(iterables);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code double}.
+	 *
+	 * @param iterators the {@link PrimitiveIterator.OfDouble}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterator.OfDouble} that iterates over the elements of each Iterator
+	 */
+	static FunctionalPrimitiveIterator.OfDouble concatDouble(Iterator<? extends PrimitiveIterator.OfDouble> iterators)
+	{
+		return new ChainedIterator.OfDouble(iterators);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code int}.
+	 *
+	 * @param iterables the {@link PrimitiveIterable.OfInt}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterable.OfInt} that iterates over the elements of each Iterable
+	 */
+	static FunctionalPrimitiveIterable.OfInt concatInt(Iterable<? extends PrimitiveIterable.OfInt> iterables)
+	{
+		return new ChainedIterable.OfInt(iterables);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code int}.
+	 *
+	 * @param iterators the {@link PrimitiveIterator.OfInt}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterator.OfInt} that iterates over the elements of each Iterator
+	 */
+	static FunctionalPrimitiveIterator.OfInt concatInt(Iterator<? extends PrimitiveIterator.OfInt> iterators)
+	{
+		return new ChainedIterator.OfInt(iterators);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code long}.
+	 *
+	 * @param iterables the {@link PrimitiveIterable.OfLong}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterable.OfLong} that iterates over the elements of each Iterable
+	 */
+	static FunctionalPrimitiveIterable.OfLong concatLong(Iterable<? extends PrimitiveIterable.OfLong> iterables)
+	{
+		return new ChainedIterable.OfLong(iterables);
+	}
+
+	/**
+	 * Primitive specialisation of {@code concat} for {@code long}.
+	 *
+	 * @param iterators the {@link PrimitiveIterator.OfLong}s to concatenate
+	 * @return a {@link FunctionalPrimitiveIterator.OfLong} that iterates over the elements of each Iterator
+	 */
+	static FunctionalPrimitiveIterator.OfLong concatLong(Iterator<? extends PrimitiveIterator.OfLong> iterators)
+	{
+		return new ChainedIterator.OfLong(iterators);
+	}
+
+	/**
 	 * Convert an Iterable&lt;Double&gt; to a FunctionalPrimitiveIterable.OfDouble by unboxing each element.
 	 * If the argument's Iterator yields {@code null}, a {@link NullPointerException} is thrown when iterating.
 	 * Answer the Iterable if it already implements of FunctionalPrimitiveIterable.OfDouble.
@@ -314,7 +404,7 @@ public interface Reducible<E, E_CAT>
 
 	/**
 	 * Concatenate the receiver and the argument.
-	 * The returned reducible first iterates over the elements of the receiver and then over the elements the argument.
+	 * The returned Reducible first iterates over the elements of the receiver and then over the elements the argument.
 	 *
 	 * @param reducible the {@link Reducible} to append
 	 * @return a {@link Reducible} that iterates over the elements of the receiver and the argument
@@ -401,7 +491,7 @@ public interface Reducible<E, E_CAT>
 	// Accumulations Methods (Consuming)
 
 	/**
-	 * Consume this reducible, i.e., iterate over all its elements.
+	 * Consume this Reducible, i.e., iterate over all its elements.
 	 */
 	default Reducible<E,E_CAT> consume()
 	{

--- a/prism/src/explicit/CTMDPSimple.java
+++ b/prism/src/explicit/CTMDPSimple.java
@@ -128,7 +128,7 @@ public class CTMDPSimple<Value> extends MDPSimple<Value> implements CTMDP<Value>
 		}
 		for (i = 0; i < numStates; i++) {
 			for (Distribution distr : trans.get(i)) {
-				distrNew = new Distribution();
+				distrNew = Distribution.ofDouble();
 				sum = (Double) distr.sum();
 				d = Math.exp(-sum * tau);
 				for (Map.Entry<Integer, Double> e : (Distribution<Double>) distr) {

--- a/prism/src/explicit/DTMCEmbeddedSimple.java
+++ b/prism/src/explicit/DTMCEmbeddedSimple.java
@@ -29,6 +29,7 @@ package explicit;
 import java.util.*;
 import java.util.Map.Entry;
 
+import common.iterable.FunctionalPrimitiveIterable;
 import explicit.rewards.MCRewards;
 import parser.State;
 import parser.Values;
@@ -86,7 +87,7 @@ public class DTMCEmbeddedSimple<Value> extends DTMCExplicit<Value>
 		return ctmc.getNumInitialStates();
 	}
 
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
 		return ctmc.getInitialStates();
 	}

--- a/prism/src/explicit/DTMCFromMDPAndMDStrategy.java
+++ b/prism/src/explicit/DTMCFromMDPAndMDStrategy.java
@@ -29,6 +29,7 @@ package explicit;
 import java.util.*;
 import java.util.Map.Entry;
 
+import common.iterable.FunctionalPrimitiveIterable;
 import explicit.rewards.MCRewards;
 import parser.State;
 import parser.Values;
@@ -76,7 +77,7 @@ public class DTMCFromMDPAndMDStrategy<Value> extends DTMCExplicit<Value>
 		return mdp.getNumInitialStates();
 	}
 
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
 		return mdp.getInitialStates();
 	}

--- a/prism/src/explicit/DTMCFromMDPMemorylessAdversary.java
+++ b/prism/src/explicit/DTMCFromMDPMemorylessAdversary.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 
+import common.iterable.FunctionalPrimitiveIterable;
 import common.iterable.Reducible;
 import parser.State;
 import parser.Values;
@@ -80,7 +81,7 @@ public class DTMCFromMDPMemorylessAdversary<Value> extends DTMCExplicit<Value>
 		return mdp.getNumInitialStates();
 	}
 
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
 		return mdp.getInitialStates();
 	}

--- a/prism/src/explicit/DTMCSimple.java
+++ b/prism/src/explicit/DTMCSimple.java
@@ -30,6 +30,8 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.io.*;
 
+import common.iterable.FunctionalPrimitiveIterator;
+import common.iterable.Reducible;
 import prism.PrismException;
 
 /**
@@ -213,9 +215,9 @@ public class DTMCSimple<Value> extends DTMCExplicit<Value> implements ModelSimpl
 
 	/** Get an iterator over the successors of state s */
 	@Override
-	public Iterator<Integer> getSuccessorsIterator(final int s)
+	public FunctionalPrimitiveIterator.OfInt getSuccessorsIterator(final int s)
 	{
-		return trans.get(s).getSupport().iterator();
+		return Reducible.unboxInt(trans.get(s).getSupport()).iterator();
 	}
 
 	@Override

--- a/prism/src/explicit/DTMCSparse.java
+++ b/prism/src/explicit/DTMCSparse.java
@@ -38,6 +38,8 @@ import java.util.PrimitiveIterator.OfInt;
 import java.util.function.Function;
 
 import common.IterableStateSet;
+import common.iterable.FunctionalPrimitiveIterator;
+import common.iterable.IterableArray;
 import common.iterable.PrimitiveIterable;
 import explicit.rewards.MCRewards;
 import prism.PrismException;
@@ -151,9 +153,9 @@ public class DTMCSparse extends DTMCExplicit<Double>
 	}
 
 	@Override
-	public OfInt getSuccessorsIterator(final int state)
+	public FunctionalPrimitiveIterator.OfInt getSuccessorsIterator(final int state)
 	{
-		return Arrays.stream(columns, rows[state], rows[state+1]).iterator();
+		return new IterableArray.OfInt(columns, rows[state], rows[state+1]).iterator();
 	}
 
 	@Override

--- a/prism/src/explicit/DTMCUniformisedSimple.java
+++ b/prism/src/explicit/DTMCUniformisedSimple.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import common.iterable.FunctionalPrimitiveIterable;
 import parser.State;
 import parser.Values;
 import prism.PrismException;
@@ -98,7 +99,7 @@ public class DTMCUniformisedSimple<Value> extends DTMCExplicit<Value>
 		return ctmc.getNumInitialStates();
 	}
 
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
 		return ctmc.getInitialStates();
 	}
@@ -120,7 +121,7 @@ public class DTMCUniformisedSimple<Value> extends DTMCExplicit<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getDeadlockStates()
+	public FunctionalPrimitiveIterable.OfInt getDeadlockStates()
 	{
 		return ctmc.getDeadlockStates();
 	}

--- a/prism/src/explicit/Distribution.java
+++ b/prism/src/explicit/Distribution.java
@@ -104,7 +104,7 @@ public class Distribution<Value> implements FunctionalIterable<Entry<Integer, Va
 	 */
 	public static Distribution<Double> ofDouble()
 	{
-		return new Distribution<>(Evaluator.createForDoubles());
+		return new Distribution<>(Evaluator.forDouble());
 	}
 
 	/**
@@ -113,7 +113,7 @@ public class Distribution<Value> implements FunctionalIterable<Entry<Integer, Va
 	 */
 	public static Distribution<Double> ofDouble(Iterator<Entry<Integer, Double>> transitions)
 	{
-		return new Distribution<Double>(transitions, Evaluator.createForDoubles());
+		return new Distribution<Double>(transitions, Evaluator.forDouble());
 	}
 
 	/**

--- a/prism/src/explicit/IDTMCSimple.java
+++ b/prism/src/explicit/IDTMCSimple.java
@@ -95,6 +95,6 @@ public class IDTMCSimple<Value> extends DTMCSimple<Interval<Value>> implements I
 	@SuppressWarnings("unchecked")
 	private void createDefaultEvaluator()
 	{
-		((IDTMCSimple<Double>) this).setEvaluator(Evaluator.createForDoubleIntervals());
+		((IDTMCSimple<Double>) this).setEvaluator(Evaluator.forDoubleInterval());
 	}
 }

--- a/prism/src/explicit/IMDPModelChecker.java
+++ b/prism/src/explicit/IMDPModelChecker.java
@@ -615,7 +615,7 @@ public class IMDPModelChecker extends ProbModelChecker
 	{
 		try {
 			IMDPModelChecker mc = new IMDPModelChecker(null);
-			Evaluator<Interval<Double>> eval = Evaluator.createForDoubleIntervals();
+			Evaluator<Interval<Double>> eval = Evaluator.forDoubleInterval();
 			IMDPSimple<Double> imdp = new IMDPSimple<>();
 			imdp.setEvaluator(eval);
 			imdp.addState();

--- a/prism/src/explicit/IMDPSimple.java
+++ b/prism/src/explicit/IMDPSimple.java
@@ -95,6 +95,6 @@ public class IMDPSimple<Value> extends MDPSimple<Interval<Value>> implements IMD
 	@SuppressWarnings("unchecked")
 	private void createDefaultEvaluator()
 	{
-		((IMDPSimple<Double>) this).setEvaluator(Evaluator.createForDoubleIntervals());
+		((IMDPSimple<Double>) this).setEvaluator(Evaluator.forDoubleInterval());
 	}
 }

--- a/prism/src/explicit/IntervalUtils.java
+++ b/prism/src/explicit/IntervalUtils.java
@@ -107,8 +107,7 @@ public class IntervalUtils
 		DoubleIntervalDistribution did = extractDoubleIntervalDistribution(distr);
 		if (delimitDoubles(did)) {
 			// Create a new Distribution if delimiting changed it
-			Distribution<Interval<Double>> distrNew = new Distribution<>();
-			distrNew.setEvaluator(distr.getEvaluator());
+			Distribution<Interval<Double>> distrNew = new Distribution<>(distr.getEvaluator());
 			for (int i = 0; i < did.size; i++) {
 				distrNew.add(did.index[i], new Interval<Double>(did.lower[i], did.upper[i]));
 			}

--- a/prism/src/explicit/Model.java
+++ b/prism/src/explicit/Model.java
@@ -39,6 +39,8 @@ import java.util.TreeMap;
 import java.util.function.IntPredicate;
 
 import common.IteratorTools;
+import common.iterable.FunctionalPrimitiveIterable;
+import common.iterable.FunctionalPrimitiveIterator;
 import explicit.graphviz.Decorator;
 import parser.State;
 import parser.Values;
@@ -77,7 +79,7 @@ public interface Model<Value>
 	/**
 	 * Get iterator over initial state list.
 	 */
-	public Iterable<Integer> getInitialStates();
+	public FunctionalPrimitiveIterable.OfInt getInitialStates();
 
 	/**
 	 * Get the index of the first initial state
@@ -101,7 +103,7 @@ public interface Model<Value>
 	 * Get iterator over states that are/were deadlocks.
 	 * (Such states may have been fixed at build-time by adding self-loops)
 	 */
-	public Iterable<Integer> getDeadlockStates();
+	public FunctionalPrimitiveIterable.OfInt getDeadlockStates();
 	
 	/**
 	 * Get list of states that are/were deadlocks.
@@ -184,7 +186,7 @@ public interface Model<Value>
 	 */
 	public default int getNumTransitions(int s)
 	{
-		return Math.toIntExact(IteratorTools.count(getSuccessorsIterator(s)));
+		return Math.toIntExact(getSuccessorsIterator(s).count());
 	}
 
 	/**
@@ -210,7 +212,7 @@ public interface Model<Value>
 	 * from {@code getSuccessors}, ensuring that there are no
 	 * duplicates.
 	 */
-	public default Iterator<Integer> getSuccessorsIterator(int s)
+	public default FunctionalPrimitiveIterator.OfInt getSuccessorsIterator(int s)
 	{
 		SuccessorsIterator successors = getSuccessors(s);
 		return successors.distinct();

--- a/prism/src/explicit/Model.java
+++ b/prism/src/explicit/Model.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.PrimitiveIterator;
@@ -38,7 +37,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.IntPredicate;
 
-import common.IteratorTools;
 import common.iterable.FunctionalPrimitiveIterable;
 import common.iterable.FunctionalPrimitiveIterator;
 import explicit.graphviz.Decorator;
@@ -673,6 +671,6 @@ public interface Model<Value>
 	@SuppressWarnings("unchecked")
 	public default Evaluator<Value> getEvaluator()
 	{
-		return (Evaluator<Value>) Evaluator.createForDoubles();
+		return (Evaluator<Value>) Evaluator.forDouble();
 	}
 }

--- a/prism/src/explicit/ModelExplicit.java
+++ b/prism/src/explicit/ModelExplicit.java
@@ -34,6 +34,8 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import common.iterable.FunctionalPrimitiveIterable;
+import common.iterable.Reducible;
 import parser.State;
 import parser.Values;
 import parser.VarList;
@@ -279,9 +281,9 @@ public abstract class ModelExplicit<Value> implements Model<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
-		return initialStates;
+		return Reducible.unboxInt(initialStates);
 	}
 
 	@Override
@@ -303,9 +305,9 @@ public abstract class ModelExplicit<Value> implements Model<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getDeadlockStates()
+	public FunctionalPrimitiveIterable.OfInt getDeadlockStates()
 	{
-		return deadlocks;
+		return Reducible.unboxInt(deadlocks);
 	}
 
 	@Override

--- a/prism/src/explicit/ModelExplicit.java
+++ b/prism/src/explicit/ModelExplicit.java
@@ -51,7 +51,7 @@ public abstract class ModelExplicit<Value> implements Model<Value>
 {
 	/** Evaluator for manipulating values in the model (of type {@code Value}) */
 	@SuppressWarnings("unchecked")
-	protected Evaluator<Value> eval = (Evaluator<Value>) Evaluator.createForDoubles();
+	protected Evaluator<Value> eval = (Evaluator<Value>) Evaluator.forDouble();
 	
 	// Basic model information
 

--- a/prism/src/explicit/POMDPModelChecker.java
+++ b/prism/src/explicit/POMDPModelChecker.java
@@ -797,7 +797,7 @@ public class POMDPModelChecker extends ProbModelChecker
 				Pair<Double, Integer> valChoice = backup.apply(belief, beliefMDPState);
 				int chosenActionIndex = valChoice.second;
 				// Build a distribution over successor belief states and add to MDP
-				Distribution<Double> distr = new Distribution<>();
+				Distribution<Double> distr = Distribution.ofDouble();
 				for (Map.Entry<Belief, Double> entry : beliefMDPState.trans.get(chosenActionIndex).entrySet()) {
 					double nextBeliefProb = entry.getValue();
 					Belief nextBelief = entry.getKey();

--- a/prism/src/explicit/STPGAbstrSimple.java
+++ b/prism/src/explicit/STPGAbstrSimple.java
@@ -31,15 +31,11 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import common.IterableStateSet;
+import common.iterable.*;
 import explicit.rewards.STPGRewards;
 import prism.PrismException;
 import prism.PrismLog;
@@ -285,17 +281,12 @@ public class STPGAbstrSimple<Value> extends ModelExplicit<Value> implements STPG
 	}
 
 	@Override
-	public Iterator<Integer> getSuccessorsIterator(final int s)
+	public FunctionalPrimitiveIterator.OfInt getSuccessorsIterator(final int s)
 	{
 		// Need to build set to avoid duplicates
 		// So not necessarily the fastest method to access successors
-		HashSet<Integer> succs = new HashSet<Integer>();
-		for (DistributionSet<Value> distrs : trans.get(s)) {
-			for (Distribution<Value> distr : distrs) {
-				succs.addAll(distr.getSupport());
-			}
-		}
-		return succs.iterator();
+		FunctionalIterable<Integer> support = Reducible.concat(trans.get(s)).flatMap(Distribution::getSupport).distinct();
+		return Reducible.unboxInt(support.iterator());
 	}
 
 	@Override

--- a/prism/src/explicit/STPGAbstrSimple.java
+++ b/prism/src/explicit/STPGAbstrSimple.java
@@ -1040,37 +1040,37 @@ public class STPGAbstrSimple<Value> extends ModelExplicit<Value> implements STPG
 			stpg.addStates(4);
 			// State 0 (s_0)
 			set = stpg.newDistributionSet(null);
-			distr = new Distribution<>();
+			distr = Distribution.ofDouble();
 			distr.set(1, 1.0);
 			set.add(distr);
 			stpg.addDistributionSet(0, set);
 			// State 1 (s_1,s_2,s_3)
 			set = stpg.newDistributionSet(null);
-			distr = new Distribution<>();
+			distr = Distribution.ofDouble();
 			distr.set(2, 1.0);
 			set.add(distr);
-			distr = new Distribution<>();
+			distr = Distribution.ofDouble();
 			distr.set(1, 1.0);
 			set.add(distr);
 			stpg.addDistributionSet(1, set);
 			set = stpg.newDistributionSet(null);
-			distr = new Distribution<>();
+			distr = Distribution.ofDouble();
 			distr.set(2, 0.5);
 			distr.set(3, 0.5);
 			set.add(distr);
-			distr = new Distribution<>();
+			distr = Distribution.ofDouble();
 			distr.set(3, 1.0);
 			set.add(distr);
 			stpg.addDistributionSet(1, set);
 			// State 2 (s_4,s_5)
 			set = stpg.newDistributionSet(null);
-			distr = new Distribution<>();
+			distr = Distribution.ofDouble();
 			distr.set(2, 1.0);
 			set.add(distr);
 			stpg.addDistributionSet(2, set);
 			// State 3 (s_6)
 			set = stpg.newDistributionSet(null);
-			distr = new Distribution<>();
+			distr = Distribution.ofDouble();
 			distr.set(3, 1.0);
 			set.add(distr);
 			stpg.addDistributionSet(3, set);

--- a/prism/src/explicit/SubNondetModel.java
+++ b/prism/src/explicit/SubNondetModel.java
@@ -35,6 +35,9 @@ import java.util.Map;
 import java.util.Set;
 
 import common.IterableStateSet;
+import common.iterable.FunctionalPrimitiveIterable;
+import common.iterable.FunctionalPrimitiveIterator;
+import common.iterable.Reducible;
 import parser.State;
 import parser.Values;
 import parser.VarList;
@@ -99,14 +102,14 @@ public class SubNondetModel<Value> implements NondetModel<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
-		List<Integer> is = new ArrayList<Integer>();
+		List<Integer> is = new ArrayList<>();
 		for (int i = initialStates.nextSetBit(0); i >= 0; i = initialStates.nextSetBit(i + 1)) {
 			is.add(translateState(i));
 		}
 
-		return is;
+		return Reducible.unboxInt(is);
 	}
 
 	@Override
@@ -128,7 +131,7 @@ public class SubNondetModel<Value> implements NondetModel<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getDeadlockStates()
+	public FunctionalPrimitiveIterable.OfInt getDeadlockStates()
 	{
 		throw new UnsupportedOperationException();
 	}

--- a/prism/src/explicit/modelviews/DTMCAlteredDistributions.java
+++ b/prism/src/explicit/modelviews/DTMCAlteredDistributions.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 
+import common.iterable.FunctionalPrimitiveIterable;
 import common.iterable.Reducible;
 import common.iterable.SingletonIterator;
 import parser.State;
@@ -105,7 +106,7 @@ public class DTMCAlteredDistributions<Value> extends DTMCView<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
 		return model.getInitialStates();
 	}
@@ -191,8 +192,7 @@ public class DTMCAlteredDistributions<Value> extends DTMCView<Value>
 
 	public static <Value> DTMCAlteredDistributions<Value> fixDeadlocks(final DTMC<Value> model)
 	{
-		final BitSet deadlockStates = new BitSet();
-		model.getDeadlockStates().forEach(deadlockStates::set);
+		final BitSet deadlockStates = model.getDeadlockStates().collect(new BitSet());
 		final DTMCAlteredDistributions<Value> fixed = addSelfLoops(model, deadlockStates);
 		fixed.deadlockStates = deadlockStates;
 		fixed.fixedDeadlocks = true;

--- a/prism/src/explicit/modelviews/MDPAdditionalChoices.java
+++ b/prism/src/explicit/modelviews/MDPAdditionalChoices.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.function.IntFunction;
 import java.util.function.IntPredicate;
 
+import common.iterable.FunctionalPrimitiveIterable;
 import common.iterable.SingletonIterator;
 import explicit.MDP;
 import parser.State;
@@ -104,7 +105,7 @@ public class MDPAdditionalChoices<Value> extends MDPView<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
 		return model.getInitialStates();
 	}
@@ -232,8 +233,7 @@ public class MDPAdditionalChoices<Value> extends MDPView<Value>
 
 	public static <Value> MDPView<Value> fixDeadlocks(final MDP<Value> model)
 	{
-		final BitSet deadlockStates = new BitSet();
-		model.getDeadlockStates().forEach(deadlockStates::set);
+		final BitSet deadlockStates = model.getDeadlockStates().collect(new BitSet());
 		final MDPView<Value> fixed = addSelfLoops(model, deadlockStates);
 		fixed.deadlockStates = deadlockStates;
 		fixed.fixedDeadlocks = true;

--- a/prism/src/explicit/modelviews/MDPDroppedAllChoices.java
+++ b/prism/src/explicit/modelviews/MDPDroppedAllChoices.java
@@ -27,13 +27,13 @@
 
 package explicit.modelviews;
 
-import java.util.BitSet;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
+import common.iterable.EmptyIterable;
 import common.iterable.EmptyIterator;
+import common.iterable.FunctionalPrimitiveIterable;
+import common.iterable.FunctionalPrimitiveIterator;
 import explicit.MDP;
 import parser.State;
 import parser.Values;
@@ -90,7 +90,7 @@ public class MDPDroppedAllChoices<Value> extends MDPView<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
 		return model.getInitialStates();
 	}
@@ -145,9 +145,9 @@ public class MDPDroppedAllChoices<Value> extends MDPView<Value>
 
 
 	@Override
-	public Iterator<Integer> getSuccessorsIterator(final int state)
+	public FunctionalPrimitiveIterator.OfInt getSuccessorsIterator(final int state)
 	{
-		return states.get(state) ? EmptyIterator.of() : model.getSuccessorsIterator(state);
+		return states.get(state) ? EmptyIterator.ofInt() : model.getSuccessorsIterator(state);
 	}
 
 

--- a/prism/src/explicit/modelviews/MDPDroppedChoicesCached.java
+++ b/prism/src/explicit/modelviews/MDPDroppedChoicesCached.java
@@ -35,6 +35,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import common.functions.PairPredicateInt;
+import common.iterable.FunctionalPrimitiveIterable;
 import explicit.Distribution;
 import explicit.MDP;
 import parser.State;
@@ -111,7 +112,7 @@ public class MDPDroppedChoicesCached<Value> extends MDPView<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
 		return model.getInitialStates();
 	}

--- a/prism/src/explicit/modelviews/MDPEquiv.java
+++ b/prism/src/explicit/modelviews/MDPEquiv.java
@@ -39,6 +39,7 @@ import java.util.function.IntUnaryOperator;
 import common.functions.PairPredicateInt;
 import common.IterableBitSet;
 import common.IterableStateSet;
+import common.iterable.FunctionalPrimitiveIterable;
 import common.iterable.Reducible;
 import explicit.BasicModelTransformation;
 import explicit.MDP;
@@ -142,7 +143,7 @@ public class MDPEquiv<Value> extends MDPView<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
 		return model.getInitialStates();
 	}

--- a/prism/src/explicit/modelviews/MDPFromDTMC.java
+++ b/prism/src/explicit/modelviews/MDPFromDTMC.java
@@ -27,12 +27,11 @@
 
 package explicit.modelviews;
 
-import java.util.BitSet;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
+import common.iterable.FunctionalPrimitiveIterable;
+import common.iterable.FunctionalPrimitiveIterator;
 import explicit.DTMC;
 import explicit.DTMCSimple;
 import explicit.MDP;
@@ -89,7 +88,7 @@ public class MDPFromDTMC<Value> extends MDPView<Value>
 	}
 
 	@Override
-	public Iterable<Integer> getInitialStates()
+	public FunctionalPrimitiveIterable.OfInt getInitialStates()
 	{
 		return model.getInitialStates();
 	}
@@ -144,7 +143,7 @@ public class MDPFromDTMC<Value> extends MDPView<Value>
 
 
 	@Override
-	public Iterator<Integer> getSuccessorsIterator(final int state)
+	public FunctionalPrimitiveIterator.OfInt getSuccessorsIterator(final int state)
 	{
 		return model.getSuccessorsIterator(state);
 	}

--- a/prism/src/explicit/rewards/ConstructRewards.java
+++ b/prism/src/explicit/rewards/ConstructRewards.java
@@ -542,7 +542,7 @@ public class ConstructRewards extends PrismComponent
 	 */
 	private <Value> void checkStateReward(double rew, Object stateIndex, ASTElement ast) throws PrismException
 	{
-		checkStateReward(rew, Evaluator.createForDoubles(), stateIndex, ast);
+		checkStateReward(rew, Evaluator.forDouble(), stateIndex, ast);
 	}
 
 	/**
@@ -555,6 +555,6 @@ public class ConstructRewards extends PrismComponent
 	 */
 	private <Value> void checkTransitionReward(double rew, Object stateIndex, ASTElement ast) throws PrismException
 	{
-		checkTransitionReward(rew, Evaluator.createForDoubles(), stateIndex, ast);
+		checkTransitionReward(rew, Evaluator.forDouble(), stateIndex, ast);
 	}
 }

--- a/prism/src/explicit/rewards/Rewards.java
+++ b/prism/src/explicit/rewards/Rewards.java
@@ -53,6 +53,6 @@ public interface Rewards<Value>
 	@SuppressWarnings("unchecked")
 	public default Evaluator<Value> getEvaluator()
 	{
-		return (Evaluator<Value>) Evaluator.createForDoubles();
+		return (Evaluator<Value>) Evaluator.forDouble();
 	}
 }

--- a/prism/src/explicit/rewards/RewardsExplicit.java
+++ b/prism/src/explicit/rewards/RewardsExplicit.java
@@ -35,7 +35,7 @@ public abstract class RewardsExplicit<Value> implements Rewards<Value>
 {
 	/** Evaluator for manipulating reward values stored here (of type {@code Value}) */
 	@SuppressWarnings("unchecked")
-	protected Evaluator<Value> eval = (Evaluator<Value>) Evaluator.createForDoubles();
+	protected Evaluator<Value> eval = (Evaluator<Value>) Evaluator.forDouble();
 
 	// Mutators
 

--- a/prism/src/parser/type/TypeInterval.java
+++ b/prism/src/parser/type/TypeInterval.java
@@ -33,7 +33,7 @@ import common.Interval;
 import parser.EvaluateContext.EvalMode;
 import prism.PrismLangException;
 
-public class TypeInterval extends Type 
+public class TypeInterval extends Type
 {
 	private static Map<Type, TypeInterval> singletons;
 	
@@ -51,22 +51,19 @@ public class TypeInterval extends Type
 
 	public static TypeInterval getInstance(Type subType)
 	{
-		if (!singletons.containsKey(subType))
-			singletons.put(subType, new TypeInterval(subType));
-			
-		return singletons.get(subType);
+		return singletons.computeIfAbsent(subType, TypeInterval::new);
 	}
-	
-	public Type getSubType() 
+
+	public Type getSubType()
 	{
 		return subType;
 	}
 
-	public void setSubType(Type subType) 
+	public void setSubType(Type subType)
 	{
 		this.subType = subType;
 	}
-	
+
 	// Methods required for Type:
 	
 	@Override
@@ -99,13 +96,13 @@ public class TypeInterval extends Type
 		// Scalar converts to singleton interval
 		if (value instanceof Double || value instanceof Integer) {
 			Object subValue = getSubType().castValueTo(value);
-			return new Interval<Object>(subValue, subValue);
+			return new Interval<>(subValue, subValue);
 		}
 		// For interval, cast low/high
 		else if (value instanceof Interval) {
 			Object lower = getSubType().castValueTo(((Interval<?>) value).getLower());
 			Object upper = getSubType().castValueTo(((Interval<?>) value).getUpper());
-			return new Interval<Object>(lower, upper);
+			return new Interval<>(lower, upper);
 		}
 		else {
 			throw new PrismLangException("Can't convert " + value.getClass() + " to type " + getTypeString());

--- a/prism/src/prism/Evaluator.java
+++ b/prism/src/prism/Evaluator.java
@@ -56,24 +56,24 @@ public interface Evaluator<Value>
 {
 	// Static methods to create Evaluator instances for common types
 	
-	public static Evaluator<Double> createForDoubles()
+	public static Evaluator<Double> forDouble()
 	{
-		return evalDbl;
+		return EvaluatorDouble.EVALUATOR_DOUBLE;
 	}
 
-	public static Evaluator<BigRational> createForBigRationals()
+	public static Evaluator<BigRational> forBigRational()
 	{
-		return evalBigRat;
+		return EvaluatorBigRational.EVALUATOR_BIG_RATIONAL;
 	}
 
-	public static Evaluator<Function> createForRationalFunctions(FunctionFactory functionFactory)
+	public static Evaluator<Function> forRationalFunction(FunctionFactory functionFactory)
 	{
 		return new EvaluatorFunction(functionFactory);
 	}
 	
-	public static Evaluator<Interval<Double>> createForDoubleIntervals()
+	public static Evaluator<Interval<Double>> forDoubleInterval()
 	{
-		return evalDblInterval;
+		return EvaluatorDoubleInterval.EVALUATOR_DOUBLE_INTERVAL;
 	}
 
 	// Methods in the Evaluator interface
@@ -146,7 +146,7 @@ public interface Evaluator<Value>
 	 * By default, this amounts to checking that it is equal to 1.
 	 * A floating-point implementation might incorporate a round-off tolerance.
 	 */
-	public void checkProbabilitySum(Value sum) throws PrismException;
+	public Value checkProbabilitySum(Value sum) throws PrismException;
 	
 	/**
 	 * Evaluate an expression in a state to type {@code Value},
@@ -242,24 +242,24 @@ public interface Evaluator<Value>
 		throw new UnsupportedOperationException("Intervals not supported for " + evalMode());
 	}
 
-	// Static Evaluator instances for common types
-	
 	// Evaluator for doubles
-	
-	static Evaluator<Double> evalDbl = new EvaluatorDouble();
-	
+
 	class EvaluatorDouble implements Evaluator<Double>
 	{
+		private static final Evaluator<Double> EVALUATOR_DOUBLE = new EvaluatorDouble();
+		private static final Double ZERO = Double.valueOf(0.0);
+		private static final Double ONE = Double.valueOf(1.0);
+
 		@Override
 		public Double zero()
 		{
-			return 0.0;
+			return ZERO;
 		}
 
 		@Override
 		public Double one()
 		{
-			return 1.0;
+			return ONE;
 		}
 
 		@Override
@@ -325,12 +325,13 @@ public interface Evaluator<Value>
 		}
 		
 		@Override
-		public void checkProbabilitySum(Double sum) throws PrismException
+		public Double checkProbabilitySum(Double sum) throws PrismException
 		{
 			// We allow round-off error here
 			if (!PrismUtils.doublesAreEqual(sum, 1.0)) {
 				throw new PrismException("Probabilities sum to " + sum);
 			}
+			return sum;
 		}
 		
 		@Override
@@ -384,16 +385,16 @@ public interface Evaluator<Value>
 		@Override
 		public Evaluator<Interval<Double>> createIntervalEvaluator()
 		{
-			return evalDblInterval;
+			return EvaluatorDoubleInterval.EVALUATOR_DOUBLE_INTERVAL;
 		}
 	};
 
 	// Evaluator for rationals (using param.BigRational)
-	
-	static Evaluator<BigRational> evalBigRat = new EvaluatorBigRational();
-	
+
 	class EvaluatorBigRational implements Evaluator<BigRational>
 	{
+		private static final Evaluator<BigRational> EVALUATOR_BIG_RATIONAL = new EvaluatorBigRational();
+
 		@Override
 		public BigRational zero()
 		{
@@ -467,11 +468,12 @@ public interface Evaluator<Value>
 		}
 		
 		@Override
-		public void checkProbabilitySum(BigRational sum) throws PrismException
+		public BigRational checkProbabilitySum(BigRational sum) throws PrismException
 		{
 			if (!isOne(sum)) {
 				throw new PrismException("Probabilities sum to " + sum);
 			}
+			return sum;
 		}
 		
 		@Override
@@ -602,7 +604,7 @@ public interface Evaluator<Value>
 		}
 		
 		@Override
-		public void checkProbabilitySum(Function sum) throws PrismException
+		public Function checkProbabilitySum(Function sum) throws PrismException
 		{
 			throw new UnsupportedOperationException();
 		}
@@ -649,21 +651,23 @@ public interface Evaluator<Value>
 	}
 	
 	// Evaluator for intervals (of doubles)
-	
-	static Evaluator<Interval<Double>> evalDblInterval = new EvaluatorDoubleInterval();
-	
+
 	class EvaluatorDoubleInterval implements Evaluator<Interval<Double>>
 	{
+		private static final Evaluator<Interval<Double>> EVALUATOR_DOUBLE_INTERVAL = new EvaluatorDoubleInterval();
+		private static final Interval<Double> ZERO = new Interval<Double>(0.0, 0.0);
+		private static final Interval<Double> ONE = new Interval<Double>(1.0, 1.0);
+
 		@Override
 		public Interval<Double> zero()
 		{
-			return new Interval<Double>(0.0, 0.0);
+			return ZERO;
 		}
 
 		@Override
 		public Interval<Double> one()
 		{
-			return new Interval<Double>(1.0, 1.0);
+			return ONE;
 		}
 
 		@Override
@@ -742,7 +746,7 @@ public interface Evaluator<Value>
 		}
 		
 		@Override
-		public void checkProbabilitySum(Interval<Double> sum) throws PrismException
+		public Interval<Double> checkProbabilitySum(Interval<Double> sum) throws PrismException
 		{
 			// For intervals, we need the sum of lower bounds to be <=1
 			// and the sum of upper bounds to be >=1
@@ -753,6 +757,7 @@ public interface Evaluator<Value>
 			if (sum.getUpper() < 1.0 - PrismUtils.epsilonDouble) {
 				throw new PrismException("Probability upper bounds sum to " + sum.getUpper() + " which is less than 1");
 			}
+			return sum;
 		}
 		
 		@Override

--- a/prism/src/prism/ModelGenerator.java
+++ b/prism/src/prism/ModelGenerator.java
@@ -50,7 +50,7 @@ public interface ModelGenerator<Value> extends ModelInfo
 	@SuppressWarnings("unchecked")
 	public default Evaluator<Value> getEvaluator()
 	{
-		return (Evaluator<Value>) Evaluator.createForDoubles();
+		return (Evaluator<Value>) Evaluator.forDouble();
 	}
 	
 	/**

--- a/prism/src/prism/RewardGenerator.java
+++ b/prism/src/prism/RewardGenerator.java
@@ -65,7 +65,7 @@ public interface RewardGenerator<Value>
 	@SuppressWarnings("unchecked")
 	public default Evaluator<Value> getRewardEvaluator()
 	{
-		return (Evaluator<Value>) Evaluator.createForDoubles();
+		return (Evaluator<Value>) Evaluator.forDouble();
 	}
 	
 	/**

--- a/prism/src/pta/BackwardsReachabilityGraph.java
+++ b/prism/src/pta/BackwardsReachabilityGraph.java
@@ -129,7 +129,7 @@ public class BackwardsReachabilityGraph
 			int tr = -1;
 			for (List<List<Integer>> list2 : list) {
 				tr++;
-				Distribution distr = new Distribution();
+				Distribution distr = Distribution.ofDouble();
 				double prob, rest = 0;
 				int j = -1;
 				for (List<Integer> dests : list2) {
@@ -139,7 +139,7 @@ public class BackwardsReachabilityGraph
 						int sNew = mdp.addState();
 						distr.add(sNew, prob);
 						for (int dest : dests) {
-							Distribution distr2 = new Distribution();
+							Distribution distr2 = Distribution.ofDouble();
 							distr2.add(dest, 1.0);
 							mdp.addChoice(sNew, distr2);
 						}
@@ -214,7 +214,7 @@ public class BackwardsReachabilityGraph
 	{
 		if (i == dests.length) {
 			//log.print(src + "/" + tr);
-			Distribution distr = new Distribution();
+			Distribution distr = Distribution.ofDouble();
 			double prob, rest = 0;
 			if (dests.length > 0) {
 				for (int j = 0; j < dests.length; j++) {

--- a/prism/src/pta/PTAAbstractRefine.java
+++ b/prism/src/pta/PTAAbstractRefine.java
@@ -226,7 +226,7 @@ public class PTAAbstractRefine extends QuantAbstractRefine
 					// Add distribution corresponding to ith transition if
 					// it is included in the set we are considering in this iteration
 					if (bitSet.get(map[i])) {
-						distr = new Distribution();
+						distr = Distribution.ofDouble();
 						count = 0;
 						for (Edge edge : st.tr.getEdges()) {
 							dest = st.dests[count];

--- a/prism/src/pta/ReachabilityGraph.java
+++ b/prism/src/pta/ReachabilityGraph.java
@@ -187,7 +187,7 @@ public class ReachabilityGraph
 		for (src = 0; src < numStates; src++) {
 			// And for each outgoing transition in PTA...
 			for (SymbolicTransition st : trans.get(src)) {
-				distr = new Distribution();
+				distr = Distribution.ofDouble();
 				count = -1;
 				for (Edge edge : st.tr.getEdges()) {
 					count++;

--- a/prism/src/simulator/ModulesFileModelGenerator.java
+++ b/prism/src/simulator/ModulesFileModelGenerator.java
@@ -111,9 +111,9 @@ public class ModulesFileModelGenerator<Value> implements ModelGenerator<Value>, 
 	private static Evaluator<?> createEvaluator(ModulesFile modulesFile, boolean exact) throws PrismException
 	{
 		if (!exact) {
-			return Evaluator.createForDoubles();
+			return Evaluator.forDouble();
 		} else {
-			return Evaluator.createForBigRationals();
+			return Evaluator.forBigRational();
 		}
 	}
 	
@@ -128,7 +128,7 @@ public class ModulesFileModelGenerator<Value> implements ModelGenerator<Value>, 
 	 */
 	public static ModulesFileModelGenerator<Function> createForRationalFunctions(ModulesFile modulesFile, FunctionFactory functionFactory, PrismComponent parent) throws PrismException
 	{
-		Evaluator<Function> eval = Evaluator.createForRationalFunctions(functionFactory);
+		Evaluator<Function> eval = Evaluator.forRationalFunction(functionFactory);
 		return new ModulesFileModelGenerator<>(modulesFile, eval, parent);
 	}
 	
@@ -142,7 +142,7 @@ public class ModulesFileModelGenerator<Value> implements ModelGenerator<Value>, 
 	 */
 	public static ModulesFileModelGenerator<Double> createForDoubles(ModulesFile modulesFile, PrismComponent parent) throws PrismException
 	{
-		Evaluator<Double> eval = Evaluator.createForDoubles();
+		Evaluator<Double> eval = Evaluator.forDouble();
 		return new ModulesFileModelGenerator<>(modulesFile, eval, parent);
 	}
 	
@@ -167,7 +167,7 @@ public class ModulesFileModelGenerator<Value> implements ModelGenerator<Value>, 
 	@SuppressWarnings("unchecked")
 	public ModulesFileModelGenerator(ModulesFile modulesFile, PrismComponent parent) throws PrismException
 	{
-		this(modulesFile, (Evaluator<Value>) Evaluator.createForDoubles(), parent);
+		this(modulesFile, (Evaluator<Value>) Evaluator.forDouble(), parent);
 	}
 	
 	/**

--- a/prism/src/strat/StrategyInfo.java
+++ b/prism/src/strat/StrategyInfo.java
@@ -153,6 +153,6 @@ public interface StrategyInfo<Value>
 	@SuppressWarnings("unchecked")
 	public default Evaluator<Value> getEvaluator()
 	{
-		return (Evaluator<Value>) Evaluator.createForDoubles();
+		return (Evaluator<Value>) Evaluator.forDouble();
 	}	
 }

--- a/prism/unit-tests/common/iterable/ReducibleStaticTest.java
+++ b/prism/unit-tests/common/iterable/ReducibleStaticTest.java
@@ -223,6 +223,278 @@ class ReducibleStaticTest
 	}
 
 	@ParameterizedTest
+	@MethodSource("getIterables")
+	void testConcatIterable(Iterable<?> iterable)
+	{
+		ArrayList<Object> expected = new ArrayList<>();
+		iterable.forEach(expected::add);
+		iterable.forEach(expected::add);
+		FunctionalIterable<Object> actual = Reducible.concat(List.of(iterable, iterable));
+		assertIterableEquals(expected, actual);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterables")
+	void testConcatIterator(Iterable<?> iterable)
+	{
+		ArrayList<Object> expected = new ArrayList<>();
+		iterable.forEach(expected::add);
+		iterable.forEach(expected::add);
+		FunctionalIterator<Object> actual = Reducible.concat(List.of(iterable.iterator(), iterable.iterator()).iterator());
+		assertIteratorEquals(expected.iterator(), actual);
+	}
+
+	@Test
+	void testConcatIterable_Empty()
+	{
+		EmptyIterable<Object> expected = EmptyIterable.of();
+		Iterable<Object> actual = Reducible.concat(EmptyIterable.of());
+		assertIterableEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatIterator_Empty()
+	{
+		EmptyIterator<Object> expected = EmptyIterator.of();
+		Iterator<Object> actual = Reducible.concat(EmptyIterator.of());
+		assertIteratorEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatIterable_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat((Iterable<Iterable<?>>) null));
+	}
+
+	@Test
+	void testConcatIterator_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat((Iterator<Iterator<?>>) null));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatIterable_NullValues(Iterable<Iterable<?>> iterable)
+	{
+		FunctionalIterable<Object> result = Reducible.concat(iterable);
+		assertThrows(NullPointerException.class, result::consume);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatIterator_NullValues(Iterable<Iterator<?>> iterable)
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat(iterable.iterator()));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesDouble")
+	void testConcatDoubleIterable(Iterable<Double> iterable)
+	{
+		ArrayList<Double> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfDouble expected = Reducible.unboxDouble(expectedBoxed);
+		FunctionalPrimitiveIterable.OfDouble unboxed = Reducible.unboxDouble(iterable);
+		FunctionalPrimitiveIterable.OfDouble actual = Reducible.concatDouble(List.of(unboxed, unboxed));
+		assertIterableEquals(expected, actual);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesDouble")
+	void testConcatDoubleIterator(Iterable<Double> iterable)
+	{
+		ArrayList<Double> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfDouble expected = Reducible.unboxDouble(expectedBoxed);
+		FunctionalPrimitiveIterable.OfDouble unboxed = Reducible.unboxDouble(iterable);
+		FunctionalPrimitiveIterator.OfDouble actual = Reducible.concatDouble(List.of(unboxed.iterator(), unboxed.iterator()).iterator());
+		assertIteratorEquals(expected.iterator(), actual);
+	}
+
+	@Test
+	void testConcatDoubleIterable_Empty()
+	{
+		EmptyIterable.OfDouble expected = EmptyIterable.ofDouble();
+		FunctionalPrimitiveIterable.OfDouble actual = Reducible.concatDouble(EmptyIterable.of());
+		assertIterableEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatDoubleIterator_Empty()
+	{
+		EmptyIterator.OfDouble expected = EmptyIterator.ofDouble();
+		FunctionalPrimitiveIterator.OfDouble actual = Reducible.concatDouble(EmptyIterator.of());
+		assertIteratorEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatDoubleIterable_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatDouble((Iterable<PrimitiveIterable.OfDouble>) null));
+	}
+
+	@Test
+	void testConcatDoubleIterator_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat((Iterator<PrimitiveIterator.OfDouble>) null));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatDoubleIterable_NullValues(Iterable<PrimitiveIterable.OfDouble> iterable)
+	{
+		FunctionalPrimitiveIterable.OfDouble result = Reducible.concatDouble(iterable);
+		assertThrows(NullPointerException.class, result::consume);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatDoubleIterator_NullValues(Iterable<PrimitiveIterator.OfDouble> iterable)
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatDouble(iterable.iterator()));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesInt")
+	void testConcatIntIterable(Iterable<Integer> iterable)
+	{
+		ArrayList<Integer> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfInt expected = Reducible.unboxInt(expectedBoxed);
+		FunctionalPrimitiveIterable.OfInt unboxed = Reducible.unboxInt(iterable);
+		FunctionalPrimitiveIterable.OfInt actual = Reducible.concatInt(List.of(unboxed, unboxed));
+		assertIterableEquals(expected, actual);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesInt")
+	void testConcatIntIterator(Iterable<Integer> iterable)
+	{
+		ArrayList<Integer> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfInt expected = Reducible.unboxInt(expectedBoxed);
+		FunctionalPrimitiveIterable.OfInt unboxed = Reducible.unboxInt(iterable);
+		FunctionalPrimitiveIterator.OfInt actual = Reducible.concatInt(List.of(unboxed.iterator(), unboxed.iterator()).iterator());
+		assertIteratorEquals(expected.iterator(), actual);
+	}
+
+	@Test
+	void testConcatIntIterable_Empty()
+	{
+		EmptyIterable.OfInt expected = EmptyIterable.ofInt();
+		FunctionalPrimitiveIterable.OfInt actual = Reducible.concatInt(EmptyIterable.of());
+		assertIterableEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatIntIterator_Empty()
+	{
+		EmptyIterator.OfInt expected = EmptyIterator.ofInt();
+		FunctionalPrimitiveIterator.OfInt actual = Reducible.concatInt(EmptyIterator.of());
+		assertIteratorEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatIntIterable_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatInt((Iterable<PrimitiveIterable.OfInt>) null));
+	}
+
+	@Test
+	void testConcatIntIterator_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat((Iterator<PrimitiveIterator.OfInt>) null));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatIntIterable_NullValues(Iterable<PrimitiveIterable.OfInt> iterable)
+	{
+		FunctionalPrimitiveIterable.OfInt result = Reducible.concatInt(iterable);
+		assertThrows(NullPointerException.class, result::consume);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatIntIterator_NullValues(Iterable<PrimitiveIterator.OfInt> iterable)
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatInt(iterable.iterator()));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesLong")
+	void testConcatLongIterable(Iterable<Long> iterable)
+	{
+		ArrayList<Long> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfLong expected = Reducible.unboxLong(expectedBoxed);
+		FunctionalPrimitiveIterable.OfLong unboxed = Reducible.unboxLong(iterable);
+		FunctionalPrimitiveIterable.OfLong actual = Reducible.concatLong(List.of(unboxed, unboxed));
+		assertIterableEquals(expected, actual);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesLong")
+	void testConcatLongIterator(Iterable<Long> iterable)
+	{
+		ArrayList<Long> expectedBoxed = new ArrayList<>();
+		iterable.forEach(expectedBoxed::add);
+		iterable.forEach(expectedBoxed::add);
+		FunctionalPrimitiveIterable.OfLong expected = Reducible.unboxLong(expectedBoxed);
+		FunctionalPrimitiveIterable.OfLong unboxed = Reducible.unboxLong(iterable);
+		FunctionalPrimitiveIterator.OfLong actual = Reducible.concatLong(List.of(unboxed.iterator(), unboxed.iterator()).iterator());
+		assertIteratorEquals(expected.iterator(), actual);
+	}
+
+	@Test
+	void testConcatLongIterable_Empty()
+	{
+		EmptyIterable.OfLong expected = EmptyIterable.ofLong();
+		FunctionalPrimitiveIterable.OfLong actual = Reducible.concatLong(EmptyIterable.of());
+		assertIterableEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatLongIterator_Empty()
+	{
+		EmptyIterator.OfLong expected = EmptyIterator.ofLong();
+		FunctionalPrimitiveIterator.OfLong actual = Reducible.concatLong(EmptyIterator.of());
+		assertIteratorEquals(expected, actual);
+	}
+
+	@Test
+	void testConcatLongIterable_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatLong((Iterable<PrimitiveIterable.OfLong>) null));
+	}
+
+	@Test
+	void testConcatLongIterator_Null()
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concat((Iterator<PrimitiveIterator.OfLong>) null));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatLongIterable_NullValues(Iterable<PrimitiveIterable.OfLong> iterable)
+	{
+		FunctionalPrimitiveIterable.OfLong result = Reducible.concatLong(iterable);
+		assertThrows(NullPointerException.class, result::consume);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getIterablesNull")
+	void testConcatLongIterator_NullValues(Iterable<PrimitiveIterator.OfLong> iterable)
+	{
+		assertThrows(NullPointerException.class, () -> Reducible.concatLong(iterable.iterator()));
+	}
+
+	@ParameterizedTest
 	@MethodSource("getIterablesDouble")
 	@DisplayName("unboxDouble() yields same sequence as the underlying iterable.")
 	void testUnboxDoubleIterable(Iterable<Double> iterable)


### PR DESCRIPTION
Various improvements:
- Rename methods `createForXXX` to `forXXX` for improved readability
- Use singleton pattern for Double, BigRational, and DoubleInterval
- Let checkProbabilityValue return the value if no Exception is thrown
- Use constants for zero and one values
- Use Map#ifAbsentPut for singletons in TypeInterval
- Minor cleanups in TypeInterval